### PR TITLE
Rulasg version update

### DIFF
--- a/ghes.bicep
+++ b/ghes.bicep
@@ -4,6 +4,7 @@ param environment_prefix string
 param environment_name string
 
 @allowed([
+  '3.6.2'
   '3.3.5'
   '3.3.2'
   '3.2.7'

--- a/ghes.parameters.json
+++ b/ghes.parameters.json
@@ -9,7 +9,7 @@
         "value": "gh"
       },
       "ghes_version":{
-          "value": "3.3.5"
+          "value": "3.6.2"
       },
       "admin_username":{
         "value": "ghesadmin"


### PR DESCRIPTION
Running a deployment got this error. After talkig with @colinbeales he pointed out to update the target and permitted version to `3.6.2`. Here the change.

```pwsh
> az deployment group create -g RG-GHES-LAb1 -f ghes.bicep -p ghes.parameters.json                                                                                                                /Volumes/GoogleDrive/My Drive/rulasg.notes/labs/octorulasgGHES/ghes-azure-bicep/ghes.bicep(50,5) : Warning no-unnecessary-dependson: Remove unnecessary dependsOn entry 'ghes_appliance_vnet'. [https://aka.ms/bicep/linter/no-unnecessary-dependson]                                                                                                                                               /Volumes/GoogleDrive/My Drive/rulasg.notes/labs/octorulasgGHES/ghes-azure-bicep/ghes.bicep(213,5) : Warning no-unnecessary-dependson: Remove unnecessary dependsOn entry 'ghes_appliance_nsg'. [https://aka.ms/bicep/linter/no-unnecessary-dependson]

Please provide securestring value for 'admin_ssh_public_key' (? for help): 
Please provide securestring value for 'admin_password' (? for help): 
If you have set an SSH public key, a password is not required.
Please provide securestring value for 'admin_password' (? for help): 
If you have set an SSH public key, a password is not required.
Please provide securestring value for 'admin_password' (? for help): 
Please provide int value for 'number_of_replicas' (? for help): 
 [1] 1
 [2] 2
 [3] 3
Please enter a choice [Default choice(1)]: 0
Valid values are [1, 2, 3]
Please provide int value for 'number_of_replicas' (? for help): 
 [1] 1
 [2] 2
 [3] 3
Please enter a choice [Default choice(1)]: 1
{"code": "InvalidTemplateDeployment", "message": "The template deployment 'ghes' is not valid according to the validation procedure. The tracking id is 'db2dcaf3-a4b3-4ec8-930e-c2f447692bfe'. See inner errors for details."}

Inner Errors: 
{"code": "InvalidParameter", "target": "imageReference", "message": "The following list of images referenced from the deployment template are not found: Publisher: GitHub, Offer: GitHub-Enterprise, Sku: GitHub-Enterprise, Version: 3.3.5. Please refer to https://docs.microsoft.com/en-us/azure/virtual-machines/windows/cli-ps-findimage for instructions on finding available images."}
PS /Volumes/GoogleDrive/My Drive/rulasg.notes/labs/octorulasgGHES/ghes-azure-bicep
```